### PR TITLE
Twf.profile pieces contributed to

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   validates_presence_of :uid, :access_token, :email
 
   has_many :tips
+  has_many :tipped_pieces, class_name: "Piece", through: :tips, source: :piece
   has_many :skills
   has_many :favorite_pieces
   has_many :pieces, through: :favorite_pieces

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,5 +27,22 @@
  </section>
 <% end %>
 <section class="pieces-contributed-to">
-  <td><%= current_user.tips.size %> # of tips contributed</td>
+  <tr class="total-tips">Overall number of tips contributed: <%= current_user.tips.size %></tr>
+  <% current_user.tipped_pieces.distinct.each do |tipped_piece| %>
+    <section id="contribution-<%= tipped_piece.id %>"
+      <p class="title">
+        <%= link_to tipped_piece.title, piece_show_path(tipped_piece.id) %>
+        <% if tipped_piece.subtitle.present? %>
+          <%= ": #{tipped_piece.subtitle}"  %>
+        <% end %>
+      </p>
+      <p class="composer">
+        Composed by: <%= tipped_piece.composer %>
+      </p>
+      <p>
+        Number of tips you've contributed to this piece:
+        <%= current_user.tips.where(piece_id: tipped_piece.id).count %>
+      </p>
+    </section>
+  <% end %>
 </section>

--- a/spec/features/user/profile_pieces_contributed_to_spec.rb
+++ b/spec/features/user/profile_pieces_contributed_to_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe "as a user on my profile page" do
+  it "I should see a section that contains the pieces I've contributed to and a number of how many contributions per piece" do
+    user = User.create!(username:"Super Student" ,uid: "12345678" ,access_token: "token" ,email: "violinioso@musician.net")
+    piece1 = Piece.create!(title: "Such a good title", subtitle: "no subtitle here", composer: "The bestest composer", api_work_id: "3513")
+    piece2 = Piece.create!(title: "So edgy", subtitle: "a study in new music", composer: "Creative Artist Type", api_work_id: "4124")
+    piece3 = Piece.create!(title: "Violin Stuff", subtitle: "E string only", composer: "Old Dead White Guy", api_work_id: "9385")
+    fav1 = FavoritePiece.create!(user_id: user.id, piece_id: piece1.id)
+    fav2 = FavoritePiece.create!(user_id: user.id, piece_id: piece2.id)
+    fav3 =FavoritePiece.create!(user_id: user.id, piece_id: piece3.id)
+    Tip.create!(difficulty_rating: 5, tip: "Remember to play in tune here, it's so hard XD", piece_id: piece1.id, user_id: user.id)
+    Tip.create!(difficulty_rating: 5, tip: "The best fingering for measures 4-100 is to only use your 4th finger. You're welcome.", piece_id: piece1.id, user_id: user.id)
+    Tip.create!(difficulty_rating: 2, tip: "New music is just noise anyway, so in mm15-16 play really loud.", piece_id: piece2.id, user_id: user.id)
+    Tip.create!(difficulty_rating: 3, tip: "Wow, I tried using only trem here and it sounds awesome", piece_id: piece2.id, user_id: user.id)
+    Tip.create!(difficulty_rating: 1, tip: "don't forget to tune you a string up a half step in the rests from 88-100", piece_id: piece2.id, user_id: user.id)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+    total_tips = user.tips.size
+
+    visit(user_path(user.id))
+    save_and_open_page
+    within(".pieces-contributed-to") do
+      within(".total-tips") do
+        expect(page).to have_content("Overall number of tips contributed")
+        expect(page).to have_content(total_tips)
+      end
+    end
+
+    within("#contribution-#{piece1.id}") do
+      expect(page).to have_link(piece1.title)
+      expect(page).to have_content("Number of tips you've contributed to this piece: #{user.tips.where(piece_id: piece1.id).count}")
+      expect(page).to have_content("Composed by: #{piece1.composer}")
+    end
+  end
+end
+
+# Story:
+# As an authenticated user,
+# When I visit the profile path,
+# I should be able to see a section on my profile page
+# that updates with pieces that I have contributed to
+# with a total count of tips per piece.

--- a/spec/features/user/profile_pieces_contributed_to_spec.rb
+++ b/spec/features/user/profile_pieces_contributed_to_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "as a user on my profile page" do
     total_tips = user.tips.size
 
     visit(user_path(user.id))
-    save_and_open_page
+
     within(".pieces-contributed-to") do
       within(".total-tips") do
         expect(page).to have_content("Overall number of tips contributed")
@@ -33,10 +33,3 @@ RSpec.describe "as a user on my profile page" do
     end
   end
 end
-
-# Story:
-# As an authenticated user,
-# When I visit the profile path,
-# I should be able to see a section on my profile page
-# that updates with pieces that I have contributed to
-# with a total count of tips per piece.


### PR DESCRIPTION
added a really cool line to the user model 
` has_many :tipped_pieces, class_name: "Piece", through: :tips, source: :piece`
tipped_pieces is now something you can call on a user, it will return the pieces that the user has created a tip on --> however, it will return duplicates if the piece has multiple tips on it from that user...I got around this by using `user.tipped_pieces.uniq` and stuff, but I bet there is a refactor that could make that automatic.